### PR TITLE
task_1b: num_runs cells can be edited

### DIFF
--- a/assignment/problem_1/task_1b_train_neural_network.ipynb
+++ b/assignment/problem_1/task_1b_train_neural_network.ipynb
@@ -781,7 +781,7 @@
    "id": "13327da5-4d1a-4e0c-a730-e80f87893907",
    "metadata": {
     "deletable": false,
-    "editable": false,
+    "editable": true,
     "nbgrader": {
      "cell_type": "code",
      "checksum": "67438125ab90285988e5340e796c4b0f",
@@ -1090,7 +1090,7 @@
    "id": "e23030e9-be70-4ea0-8621-1e10c687bf38",
    "metadata": {
     "deletable": false,
-    "editable": false,
+    "editable": true,
     "nbgrader": {
      "cell_type": "code",
      "checksum": "ea0a78c45020729191bbcf80bee6477c",


### PR DESCRIPTION
In task 1b, we are asked to change the values of `num_runs` but the cell is not editable. I just changed the option `editable` to `true` for both cells. 

Additionally, I think that as we are also asked to change the value of the learning rate, we could also include that variable in this cell too. Let me know if this could be useful 